### PR TITLE
Janky workaround for Actions not being downloaded with Git LFS

### DIFF
--- a/.github/workflows/release-solution-ubuntu.yml
+++ b/.github/workflows/release-solution-ubuntu.yml
@@ -48,26 +48,34 @@ jobs:
       RUNNER_DEBUG: 1
 
     steps:
+    - name: Replace actions with fresh pull and LFS checkout
+      run: |
+        rm -rf "/home/runner/work/_actions/microsoft/powerplatform-actions/0.5.1"
+        cd "/home/runner/work/_actions/microsoft/powerplatform-actions/"
+        git clone --depth 1 --branch 0.5.1 https://github.com/microsoft/powerplatform-actions 0.5.1
+        cd ./0.5.1
+        git lfs checkout
+
     - uses: actions/checkout@v2
       with:
         lfs: true
 
     #- name: Pack solution
-     # uses: microsoft/powerplatform-actions@0.4.1
+     # uses: microsoft/powerplatform-actions@0.5.1
       #with:
        # solution-folder: ${{ github.event.inputs.solution_source_folder}}/${{ github.event.inputs.solution_name }}
         #solution-file: ${{ github.event.inputs.solution_outbound_folder}}/${{ github.event.inputs.solution_name }}.zip
         #solution-type: Unmanaged
     - name: who-am-i action
-      uses: microsoft/powerplatform-actions/who-am-i@0.4.1
+      uses: microsoft/powerplatform-actions/who-am-i@0.5.1
       with:
-        environment-url: ${{env.ENVIRONMENT_URL}}
+        environment-url: ${{env.BUILD_ENVIRONMENT_URL}}
         app-id: ${{env.CLIENT_ID}}
         client-secret: ${{ secrets.PowerPlatformSPN }}
         tenant-id: ${{env.TENANT_ID}}
     
     - name: Import solution as unmanaged to build env
-      uses: microsoft/powerplatform-actions/import-solution@0.4.1
+      uses: microsoft/powerplatform-actions/import-solution@0.5.1
       with:
         environment-url: ${{env.BUILD_ENVIRONMENT_URL}}
         app-id: ${{env.CLIENT_ID}}
@@ -102,6 +110,14 @@ jobs:
       RUNNER_DEBUG: 1
 
     steps:
+    - name: Replace actions with fresh pull and LFS checkout
+      run: |
+        rm -rf "/home/runner/work/_actions/microsoft/powerplatform-actions/0.5.1"
+        cd "/home/runner/work/_actions/microsoft/powerplatform-actions/"
+        git clone --depth 1 --branch 0.5.1 https://github.com/microsoft/powerplatform-actions 0.5.1
+        cd ./0.5.1
+        git lfs checkout
+
     - uses: actions/checkout@v2
       with:
         lfs: true

--- a/.github/workflows/release-solution-ubuntu.yml
+++ b/.github/workflows/release-solution-ubuntu.yml
@@ -105,7 +105,7 @@ jobs:
 
   release-to-staging:
     needs: [ convert-to-managed ]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     env:
       RUNNER_DEBUG: 1
 

--- a/.github/workflows/release-solution.yml
+++ b/.github/workflows/release-solution.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Try forcing LFS checkout of actions
       run: |
         pwd
-        cd ..\_actions\microsoft\powerplatform-actions\0.5.1\
+        cd ..\..\_actions\microsoft\powerplatform-actions\0.5.1\
         git lfs checkout
 
     #- name: Setup .NET

--- a/.github/workflows/release-solution.yml
+++ b/.github/workflows/release-solution.yml
@@ -40,6 +40,7 @@ env:
   TENANT_ID: 'ec6b17bb-11d0-4195-abd0-521c69a5d1fd'
 
 jobs:
+
   convert-to-managed:
     #runs-on: ubuntu-latest
     runs-on: windows-latest
@@ -51,6 +52,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         lfs: true
+
+    - name: Try forcing LFS checkout of actions
+      run: |
+        pwd
+        cd ..\_actions\microsoft\powerplatform-actions\0.5.1\
+        git lfs checkout
 
     #- name: Setup .NET
     #  uses: actions/setup-dotnet@v1

--- a/.github/workflows/release-solution.yml
+++ b/.github/workflows/release-solution.yml
@@ -84,7 +84,7 @@ jobs:
     - name: who-am-i action
       uses: microsoft/powerplatform-actions/who-am-i@0.5.1
       with:
-        environment-url: ${{env.ENVIRONMENT_URL}}
+        environment-url: ${{env.BUILD_ENVIRONMENT_URL}}
         app-id: ${{env.CLIENT_ID}}
         client-secret: ${{ secrets.PowerPlatformSPN }}
         tenant-id: ${{env.TENANT_ID}}

--- a/.github/workflows/release-solution.yml
+++ b/.github/workflows/release-solution.yml
@@ -66,7 +66,8 @@ jobs:
         pwd
         cd ..\..\_actions\microsoft\powerplatform-actions\
         pwd
-        git clone git clone --depth 1 --branch 0.5.1 https://github.com/microsoft/powerplatform-actions 0.5.1
+        git clone --depth 1 --branch 0.5.1 https://github.com/microsoft/powerplatform-actions 0.5.1
+        cd .\0.5.1
         git lfs checkout
 
     #- name: Setup .NET

--- a/.github/workflows/release-solution.yml
+++ b/.github/workflows/release-solution.yml
@@ -62,6 +62,7 @@ jobs:
       run: |
         pwd
         cd ..\..\_actions\microsoft\powerplatform-actions\
+        pwd
         del .\0.5.1
         git clone git clone --depth 1 --branch 0.5.1 https://github.com/microsoft/powerplatform-actions 0.5.1
         git lfs checkout

--- a/.github/workflows/release-solution.yml
+++ b/.github/workflows/release-solution.yml
@@ -90,7 +90,7 @@ jobs:
         tenant-id: ${{env.TENANT_ID}}
     
     - name: Import solution as unmanaged to build env
-      uses: microsoft/powerplatform-actions/import-solution@0.4.1
+      uses: microsoft/powerplatform-actions/import-solution@0.5.1
       with:
         environment-url: ${{env.BUILD_ENVIRONMENT_URL}}
         app-id: ${{env.CLIENT_ID}}

--- a/.github/workflows/release-solution.yml
+++ b/.github/workflows/release-solution.yml
@@ -53,6 +53,9 @@ jobs:
       with:
         lfs: true
 
+    - name: remove current copy of actions
+      run: remove-item -LiteralPath "D:\a\_actions\microsoft\powerplatform-actions\0.5.1\" -Force -Recurse
+
     - name: Try forcing LFS checkout of actions
       # run: |
       #   pwd
@@ -63,7 +66,6 @@ jobs:
         pwd
         cd ..\..\_actions\microsoft\powerplatform-actions\
         pwd
-        del .\0.5.1
         git clone git clone --depth 1 --branch 0.5.1 https://github.com/microsoft/powerplatform-actions 0.5.1
         git lfs checkout
 

--- a/.github/workflows/release-solution.yml
+++ b/.github/workflows/release-solution.yml
@@ -54,10 +54,16 @@ jobs:
         lfs: true
 
     - name: Try forcing LFS checkout of actions
+      # run: |
+      #   pwd
+      #   cd ..\..\_actions\microsoft\powerplatform-actions\0.5.1\
+      #   pwd
+      #   git lfs checkout
       run: |
         pwd
-        cd ..\..\_actions\microsoft\powerplatform-actions\0.5.1\
-        pwd
+        cd ..\..\_actions\microsoft\powerplatform-actions\
+        del .\0.5.1
+        git clone git clone --depth 1 --branch 0.5.1 https://github.com/microsoft/powerplatform-actions 0.5.1
         git lfs checkout
 
     #- name: Setup .NET

--- a/.github/workflows/release-solution.yml
+++ b/.github/workflows/release-solution.yml
@@ -49,26 +49,17 @@ jobs:
       RUNNER_DEBUG: 1
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        lfs: true
-
-    - name: remove current copy of actions
-      run: remove-item -LiteralPath "D:\a\_actions\microsoft\powerplatform-actions\0.5.1\" -Force -Recurse
-
-    - name: Try forcing LFS checkout of actions
-      # run: |
-      #   pwd
-      #   cd ..\..\_actions\microsoft\powerplatform-actions\0.5.1\
-      #   pwd
-      #   git lfs checkout
+    - name: Replace actions with fresh pull and LFS checkout
       run: |
-        pwd
+        remove-item -LiteralPath "D:\a\_actions\microsoft\powerplatform-actions\0.5.1\" -Force -Recurse
         cd ..\..\_actions\microsoft\powerplatform-actions\
-        pwd
         git clone --depth 1 --branch 0.5.1 https://github.com/microsoft/powerplatform-actions 0.5.1
         cd .\0.5.1
         git lfs checkout
+
+    - uses: actions/checkout@v2
+      with:
+        lfs: true
 
     #- name: Setup .NET
     #  uses: actions/setup-dotnet@v1
@@ -125,6 +116,14 @@ jobs:
       RUNNER_DEBUG: 1
 
     steps:
+    - name: Replace actions with fresh pull and LFS checkout
+      run: |
+        remove-item -LiteralPath "D:\a\_actions\microsoft\powerplatform-actions\0.5.1\" -Force -Recurse
+        cd ..\..\_actions\microsoft\powerplatform-actions\
+        git clone --depth 1 --branch 0.5.1 https://github.com/microsoft/powerplatform-actions 0.5.1
+        cd .\0.5.1
+        git lfs checkout
+
     - uses: actions/checkout@v2
       with:
         lfs: true

--- a/.github/workflows/release-solution.yml
+++ b/.github/workflows/release-solution.yml
@@ -57,6 +57,7 @@ jobs:
       run: |
         pwd
         cd ..\..\_actions\microsoft\powerplatform-actions\0.5.1\
+        pwd
         git lfs checkout
 
     #- name: Setup .NET


### PR DESCRIPTION
Janky workaround for Actions not being downloaded with Git LFS

Deletes the downloaded Action, then clones the action's repo into that same folder.